### PR TITLE
Returns <li> are now a click through url

### DIFF
--- a/Assets/script.js
+++ b/Assets/script.js
@@ -20,8 +20,9 @@ function renderResults(npsApiResponse) {
     var respData = npsApiResponse.data;
     for (let i = 0; i < respData.length; i++) {
         // ? a condition that checks if the property exists
-        var resultEl = $('<li>').addClass('user-select').text(`${respData[i]?.name} ${respData[i].url}`);
-        
+        var resultEl = $('<li>').addClass('user-select');
+        var anchorEl = $('<a>').text(`${respData[i]?.name}`).attr("href", `${respData[i].url}`);
+        resultEl.append(anchorEl);
         $('.search-results').append(resultEl);
         
     }


### PR DESCRIPTION
The change in the script file changes the return data to the name of the campground but makes it possible to select the campground and click-through to the provided URL.